### PR TITLE
Fix compatibility with Nimskull by using proper destructors

### DIFF
--- a/examples/abstractitemmodel/main.nim
+++ b/examples/abstractitemmodel/main.nim
@@ -3,16 +3,9 @@ import NimQml, mylistmodel
 proc mainProc() =
   echo "Starting"
   var app = newQApplication()
-  defer: app.delete
-
   var myListModel = newMyListModel();
-  defer: myListModel.delete
-
   var engine = newQQmlApplicationEngine()
-  defer: engine.delete
-
   var variant = newQVariant(myListModel)
-  defer: variant.delete
 
   engine.setRootContextProperty("myListModel", variant)
   engine.load("main.qml")

--- a/examples/abstractitemmodel/mylistmodel.nim
+++ b/examples/abstractitemmodel/mylistmodel.nim
@@ -9,15 +9,11 @@ QtObject:
     MyListModel* = ref object of QAbstractListModel
       names*: seq[string]
 
-  proc delete(self: MyListModel)
   proc setup(self: MyListModel)
   proc newMyListModel*(): MyListModel =
-    new(result, delete)
+    new(result)
     result.names = @["John", "Max", "Paul", "Anna"]
     result.setup
-
-  proc delete(self: MyListModel) =
-    self.QAbstractListModel.delete
 
   proc setup(self: MyListModel) =
     self.QAbstractListModel.setup

--- a/examples/charts/main.nim
+++ b/examples/charts/main.nim
@@ -3,16 +3,9 @@ import NimQml, mylistmodel
 proc mainProc() =
   echo "Starting"
   var app = newQApplication()
-  defer: app.delete
-
   var myListModel = newMyListModel();
-  defer: myListModel.delete
-
   var engine = newQQmlApplicationEngine()
-  defer: engine.delete
-
   var variant = newQVariant(myListModel)
-  defer: variant.delete
 
   engine.setRootContextProperty("myListModel", variant)
   engine.load("main.qml")

--- a/examples/charts/mylistmodel.nim
+++ b/examples/charts/mylistmodel.nim
@@ -12,10 +12,9 @@ QtObject:
       maxX: int
       maxY: int
 
-  proc delete(self: MyListModel)
   proc setup(self: MyListModel)
   proc newMyListModel*(): MyListModel =
-    new(result, delete)
+    new(result)
     result.setup
 
   method rowCount(self: MyListModel, index: QModelIndex = nil): int =
@@ -66,9 +65,6 @@ QtObject:
       self.maxYChanged(y)
     self.points.add(Point(x: x, y: y))
     self.endInsertRows()
-
-  proc delete(self: MyListModel) =
-    self.QAbstractTableModel.delete
 
   proc setup(self: MyListModel) =
     self.QAbstractTableModel.setup

--- a/examples/connections/main.nim
+++ b/examples/connections/main.nim
@@ -5,15 +5,11 @@ QtObject:
   type Contact* = ref object of QObject
     name: string
 
-  proc delete*(self: Contact)
   proc setup(self: Contact)
   proc newContact(): Contact =
-    new(result, delete)
+    new(result)
     result.name = ""
     result.setup
-
-  proc delete*(self: Contact) =
-    self.QObject.delete
 
   proc setup(self: Contact) =
     self.QObject.setup
@@ -83,7 +79,6 @@ proc main() =
     let c1 = newContact()
     block:
       let c2 = newContact()
-      defer: c2.delete
       discard QObject.connect(c1, nameChanged, c2, setName)
       assert(c1.name != "John" and c2.name != "John")
       c1.setName("John")

--- a/examples/contactapp/applicationlogic.nim
+++ b/examples/contactapp/applicationlogic.nim
@@ -6,17 +6,12 @@ QtObject:
     app: QApplication
 
   proc setup(self: ApplicationLogic)
-  proc delete*(self: ApplicationLogic)
 
   proc newApplicationLogic*(app: QApplication): ApplicationLogic =
-    new(result, delete)
+    new(result)
     result.contactList = newContactList()
     result.app = app
     result.setup()
-
-  proc delete*(self: ApplicationLogic) =
-    self.QObject.delete
-    self.contactList.delete
 
   proc setup(self: ApplicationLogic) =
     self.QObject.setup

--- a/examples/contactapp/contact.nim
+++ b/examples/contactapp/contact.nim
@@ -5,16 +5,12 @@ QtObject:
     name: string
     surname: string
 
-  proc delete*(self: Contact)
   proc setup(self: Contact)
 
   proc newContact*(): Contact =
-    new(result, delete)
+    new(result)
     result.name = ""
     result.setup
-
-  proc delete*(self: Contact) =
-    self.QObject.delete
 
   proc setup(self: Contact) =
     self.QObject.setup

--- a/examples/contactapp/contactlist.nim
+++ b/examples/contactapp/contactlist.nim
@@ -10,21 +10,14 @@ QtObject:
     ContactList* = ref object of QAbstractListModel
       contacts*: seq[Contact]
 
-  proc delete(self: ContactList)
   proc setup(self: ContactList)
   proc newContactList*(): ContactList =
-    new(result, delete)
+    new(result)
     result.contacts = @[]
     result.setup
 
   proc setup(self: ContactList) =
     self.QAbstractListModel.setup
-
-  proc delete(self: ContactList) =
-    self.QAbstractListModel.delete
-    for contact in self.contacts:
-      contact.delete
-    self.contacts = @[]
 
   method rowCount(self: ContactList, index: QModelIndex = nil): int =
     return self.contacts.len

--- a/examples/contactapp/main.nim
+++ b/examples/contactapp/main.nim
@@ -3,16 +3,9 @@ import applicationlogic
 
 proc mainProc() =
   let app = newQApplication()
-  defer: app.delete
-
   let logic = newApplicationLogic(app)
-  defer: logic.delete
-
   let engine = newQQmlApplicationEngine()
-  defer: engine.delete
-
   let logicVariant = newQVariant(logic)
-  defer: logicVariant.delete
 
   engine.setRootContextProperty("logic", logicVariant)
   engine.load("main.qml")

--- a/examples/helloworld/main.nim
+++ b/examples/helloworld/main.nim
@@ -2,10 +2,8 @@ import NimQml
 
 proc mainProc() =
   var app = newQApplication()
-  defer: app.delete()
 
   var engine = newQQmlApplicationEngine()
-  defer: engine.delete()
 
   engine.load("main.qml")
   app.exec()

--- a/examples/helloworld/main.qml
+++ b/examples/helloworld/main.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.2
-import QtQuick.Controls 1.2
-import QtQuick.Layouts 1.1
-import QtQuick.Window 2.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
 ApplicationWindow {
     width: 400

--- a/examples/qmlregistertype/main.nim
+++ b/examples/qmlregistertype/main.nim
@@ -4,12 +4,8 @@ import macros
 
 proc mainProc() =
   var app = newQApplication()
-  defer: app.delete()
-
   let id = qmlRegisterType("ContactModule", 1, 0, "Contact", proc(): Contact = newContact());
-
   var engine = newQQmlApplicationEngine()
-  defer: engine.delete()
 
   engine.load("main.qml")
   app.exec()

--- a/examples/resourcebundling/main.nim
+++ b/examples/resourcebundling/main.nim
@@ -2,9 +2,7 @@ import nimqml
 
 proc mainProc() =
   let app = newQApplication()
-  defer: app.delete
   let engine = newQQmlApplicationEngine()
-  defer: engine.delete
   let appDirPath = app.applicationDirPath & "/" & "main.rcc"
   QResource.registerResource(appDirPath)
   engine.load(newQUrl("qrc:///main.qml"))

--- a/examples/simpledata/main.nim
+++ b/examples/simpledata/main.nim
@@ -2,22 +2,11 @@ import NimQml
 
 proc mainProc() =
   var app = newQApplication()
-  defer: app.delete()
-
   var engine = newQQmlApplicationEngine()
-  defer: engine.delete()
-
   var qVar1 = newQVariant(10)
-  defer: qVar1.delete()
-
   var qVar2 = newQVariant("Hello World")
-  defer: qVar2.delete()
-
   var qVar3 = newQVariant(false)
-  defer: qVar3.delete()
-
   var qVar4 = newQVariant(3.5.float)
-  defer: qVar4.delete()
 
   engine.setRootContextProperty("qVar1", qVar1)
   engine.setRootContextProperty("qVar2", qVar2)

--- a/examples/slotsandproperties/contact.nim
+++ b/examples/slotsandproperties/contact.nim
@@ -4,15 +4,11 @@ QtObject:
   type Contact* = ref object of QObject
     m_name: string
 
-  proc delete*(self: Contact)
   proc setup(self: Contact)
   proc newContact*(): Contact =
-    new(result, delete)
+    new(result)
     result.m_name = "InitialName"
     result.setup
-
-  proc delete*(self: Contact) =
-    self.QObject.delete
 
   proc setup(self: Contact) =
     self.QObject.setup

--- a/examples/slotsandproperties/main.nim
+++ b/examples/slotsandproperties/main.nim
@@ -3,16 +3,9 @@ import contact
 
 proc mainProc() =
   var app = newQApplication()
-  defer: app.delete()
-
   var contact = newContact()
-  defer: contact.delete()
-
   var engine = newQQmlApplicationEngine()
-  defer: engine.delete()
-
   var variant = newQVariant(contact)
-  defer: variant.delete()
 
   engine.setRootContextProperty("contact", variant)
   engine.load("main.qml")

--- a/src/nimqml/private/constructors.nim
+++ b/src/nimqml/private/constructors.nim
@@ -1,43 +1,33 @@
 ############# QObject #############
 proc setup*(self: QObject) 
-proc delete*(self: QObject) =
-  debugMsg("QObject", "delete")
-  ## Delete a QObject
-  if not self.owner or self.vptr.isNil:
-    return
-  dos_qobject_delete(self.vptr)
-  self.vptr.resetToNil
 
 proc newQObject*(): QObject =
   ## Return a new QObject
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QAbstractItemModel #############
 proc setup*(self: QAbstractItemModel)
-proc delete*(self: QAbstractItemModel)
 proc newQAbstractItemModel*(): QAbstractItemModel =
   ## Return a new QAbstractItemModel
   debugMsg("QAbstractItemModel", "new")
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QAbstractListModel #############
 proc setup*(self: QAbstractListModel)
-proc delete*(self: QAbstractListModel)
 proc newQAbstractListModel*(): QAbstractListModel =
   ## Return a new QAbstractListModel
   debugMsg("QAbstractListModel", "new")
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QAbstractTableModel #############
 proc setup*(self: QAbstractTableModel)
-proc delete*(self: QAbstractTableModel)
 proc newQAbstractTableModel*(): QAbstractTableModel =
   ## Return a new QAbstractTableModel
   debugMsg("QAbstractTableModel", "new")
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QVariant #############
@@ -50,91 +40,85 @@ proc setup*(variant: QVariant, value: DosQVariant, takeOwnership: Ownership)
 proc setup*(variant: QVariant, value: cfloat)
 proc setup*(variant: QVariant, value: cdouble)
 proc setup*(variant: QVariant, value: QVariant)
-proc delete*(variant: QVariant)
 
 proc newQVariant*(): QVariant =
   ## Return a new QVariant
-  new(result, delete)
+  new(result)
   result.setup()
 
 proc newQVariant*(value: int): QVariant =
   ## Return a new QVariant given a cint
-  new(result, delete)
+  new(result)
   result.setup(value)
 
 proc newQVariant*(value: bool): QVariant =
   ## Return a new QVariant given a bool
-  new(result, delete)
+  new(result)
   result.setup(value)
 
 proc newQVariant*(value: string): QVariant =
   ## Return a new QVariant given a string
-  new(result, delete)
+  new(result)
   result.setup(value)
 
 proc newQVariant*(value: QObject): QVariant =
   ## Return a new QVariant given a QObject
-  new(result, delete)
+  new(result)
   result.setup(value)
 
 proc newQVariant(value: DosQVariant, takeOwnership: Ownership): QVariant =
   ## Return a new QVariant given a raw QVariant pointer
-  new(result, delete)
+  new(result)
   result.setup(value, takeOwnership)
 
 proc newQVariant*(value: QVariant): QVariant =
   ## Return a new QVariant given another QVariant
-  new(result, delete)
+  new(result)
   result.setup(value)
 
 proc newQVariant*(value: cfloat): QVariant =
   ## Return a new QVariant given a float
-  new(result, delete)
+  new(result)
   result.setup(value)
 
 ############# QUrl #############
 proc setup*(self: QUrl, url: string, mode: QUrlParsingMode)
-proc delete*(self: QUrl)
 proc newQUrl*(url: string, mode: QUrlParsingMode = QUrlParsingMode.Tolerant): QUrl =
   ## Create a new QUrl
-  new(result, delete)
+  new(result)
   result.setup(url, mode)
 
 ############# QQuickView #############
 proc setup*(self: QQuickView)
-proc delete*(self: QQuickView)
 proc newQQuickView*(): QQuickView =
   ## Return a new QQuickView
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QQmlApplicationEngine #############
 proc setup*(self: QQmlApplicationEngine)
-proc delete*(self: QQmlApplicationEngine)
 proc newQQmlApplicationEngine*(): QQmlApplicationEngine =
   ## Return a new QQmlApplicationEngine
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QModelIndex #############
 proc setup*(self: QModelIndex)
 proc setup(self: QModelIndex, other: DosQModelIndex, takeOwnership: Ownership)
-proc delete*(self: QModelIndex)
 
 proc newQModelIndex*(): QModelIndex =
   ## Return a new QModelIndex
-  new(result, delete)
+  new(result)
   result.setup()
 
 proc newQModelIndex(vptr: DosQModelIndex, takeOwnership: Ownership): QModelIndex =
   ## Return a new QModelIndex given a raw index
-  new(result, delete)
+  new(result)
   result.setup(vptr, takeOwnership)  
 
 ############# QMetaObjectConnection #############
-proc delete*(self: QMetaObjectConnection)
 proc new*(typ: type QMetaObjectConnection, vptr: DosQMetaObjectConnection): QMetaObjectConnection =
-  new(result, delete)
+  new(result)
   result.vptr = vptr  
 
 ############# QMetaObject #############
@@ -143,30 +127,29 @@ proc setup(superClass: QMetaObject,
            signals: seq[SignalDefinition],
            slots: seq[SlotDefinition],
            properties: seq[PropertyDefinition]): DosQMetaObject
-proc delete*(metaObject: QMetaObject)
 
 proc newQObjectMetaObject*(): QMetaObject =
   ## Create the QMetaObject of QObject
   debugMsg("QMetaObject", "newQObjectMetaObject")
-  new(result, delete)
+  new(result)
   result.vptr = dos_qobject_qmetaobject()
 
 proc newQAbstractItemModelMetaObject*(): QMetaObject =
   ## Create the QMetaObject of QAbstractItemModel
   debugMsg("QMetaObject", "newQAbstractItemModelMetaObject")
-  new(result, delete)
+  new(result)
   result.vptr = dos_qabstractitemmodel_qmetaobject()
 
 proc newQAbstractListModelMetaObject*(): QMetaObject =
   ## Create the QMetaObject of QAbstractListModel
   debugMsg("QMetaObject", "newQAbstractListModelMetaObject")
-  new(result, delete)
+  new(result)
   result.vptr = dos_qabstractlistmodel_qmetaobject()
 
 proc newQAbstractTableModelMetaObject*(): QMetaObject =
   ## Create the QMetaObject of QAbstractTableModel
   debugMsg("QMetaObject", "newQAbstractItemTableMetaObject")
-  new(result, delete)
+  new(result)
   result.vptr = dos_qabstracttablemodel_qmetaobject()
 
 proc newQMetaObject*(superClass: QMetaObject, className: string,
@@ -175,7 +158,7 @@ proc newQMetaObject*(superClass: QMetaObject, className: string,
                      properties: seq[PropertyDefinition]): QMetaObject =
   ## Create a new QMetaObject
   debugMsg("QMetaObject", "newQMetaObject" & className)
-  new(result, delete)
+  new(result)
   result.signals = signals
   result.slots = slots
   result.properties = properties
@@ -183,18 +166,16 @@ proc newQMetaObject*(superClass: QMetaObject, className: string,
 
 ############# QHashIntByteArray #############
 proc setup*(self: QHashIntByteArray)
-proc delete*(self: QHashIntByteArray)
 proc newQHashIntQByteArray*(): QHashIntByteArray =
   ## Create a new QHashIntQByteArray
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# QGuiApplication #############
 proc setup*(self: QGuiApplication)
-proc delete*(self: QGuiApplication)
 proc newQGuiApplication*(): QGuiApplication =
   ## Return a new QApplication
-  new(result, delete)
+  new(result)
   result.setup()
 
 ############# LambdaInvoker #############

--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -109,7 +109,6 @@ type
   DosQMetaObjectInvokeMethodCallback = proc(data: pointer) {.cdecl.}
 
 # Conversion
-proc resetToNil[T](x: var T) = x = nil.pointer.T
 proc isNil(x: DosQMetaObject): bool = x.pointer.isNil
 proc isNil(x: DosQVariant): bool = x.pointer.isNil
 proc isNil(x: DosQObject): bool = x.pointer.isNil

--- a/src/nimqml/private/nimqmltypes.nim
+++ b/src/nimqml/private/nimqmltypes.nim
@@ -1,47 +1,60 @@
 type
-  QObject* = ref object of RootObj ## \
+  QObject* = ref QObjectObj
+  QObjectObj* = object of RootObj ## \
     ## A QObject
     vptr: DosQObject
     owner: bool
 
-  QAbstractItemModel* = ref object of QObject ## \
+  QAbstractItemModel* = ref QAbstractItemModelObj
+  QAbstractItemModelObj* = object of QObject ## \
     ## A QAbstractItemModel
 
-  QAbstractListModel* = ref object of QAbstractItemModel ## \
+  QAbstractListModel* = ref QAbstractListModelObj
+  QAbstractListModelObj* = object of QAbstractItemModel ## \
     ## A QAbstractListModel
 
-  QAbstractTableModel* = ref object of QAbstractItemModel ## \
+  QAbstractTableModel* = ref QAbstractTableModelObj
+  QAbstractTableModelObj* = object of QAbstractItemModel ## \
     ## A QAbstractTableModel
 
-  QVariant* = ref object of RootObj ## \
+  QVariant* = ref QVariantObj
+  QVariantObj* = object of RootObj ## \
     ## A QVariant
     vptr: DosQVariant
 
-  QQmlApplicationEngine* = ref object of RootObj ## \
+  QQmlApplicationEngine* = ref QQmlApplicationEngineObj
+  QQmlApplicationEngineObj* = object of RootObj ## \
     ## A QQmlApplicationEngine
     vptr: DosQQmlApplicationEngine
 
-  QCoreApplication* = ref object of RootObj ## \
+  QCoreApplication* = ref QCoreApplicationObj
+  QCoreApplicationObj* = object of RootObj ## \
     ## A QCoreApplication
     deleted: bool
 
-  QGuiApplication* = ref object of QCoreApplication ## \
+  QGuiApplication* = ref QGuiApplicationObj
+  QGuiApplicationObj* = object of QCoreApplication ## \
 
-  QApplication* = ref object of QGuiApplication ## \
+  QApplication* = ref QApplicationObj
+  QApplicationObj* = object of QGuiApplication ## \
 
-  QQuickView* = ref object of RootObj ## \
+  QQuickView* = ref QQuickViewObj
+  QQuickViewObj* = object of RootObj ## \
     # A QQuickView
     vptr: DosQQuickView
 
-  QHashIntByteArray* = ref object of RootObj ## \
+  QHashIntByteArray* = ref QHashIntByteArrayObj
+  QHashIntByteArrayObj* = object of RootObj ## \
     # A QHash<int, QByteArray>
     vptr: DosQHashIntByteArray
 
-  QModelIndex* = ref object of RootObj ## \
+  QModelIndex* = ref QModelIndexObj
+  QModelIndexObj* = object of RootObj ## \
     # A QModelIndex
     vptr: DosQModelIndex
 
-  QResource* = ref object of RootObj ## \
+  QResource* = ref QResourceObj
+  QResourceObj* = object of RootObj ## \
     # A QResource
 
   QtItemFlag*{.pure, size: sizeof(cint).} = enum ## \
@@ -108,13 +121,15 @@ type
     writeSlot*: string
     notifySignal*: string
 
-  QMetaObject* = ref object of RootObj
+  QMetaObject* = ref QMetaObjectObj
+  QMetaObjectObj* = object of RootObj
     vptr: DosQMetaObject
     signals: seq[SignalDefinition]
     slots: seq[SlotDefinition]
     properties: seq[PropertyDefinition]
 
-  QUrl* = ref object of RootObj
+  QUrl* = ref QUrlObj
+  QUrlObj* = object of RootObj
     vptr: DosQUrl
 
   QUrlParsingMode*{.pure, size: sizeof(cint).} = enum
@@ -126,7 +141,8 @@ type
     Take,                   # The ownership is passed to the wrapper
     Clone                   # The node should be cloned
 
-  QMetaObjectConnection = ref object
+  QMetaObjectConnection = ref QMetaObjectConnectionObj
+  QMetaObjectConnectionObj = object
     vptr: DosQMetaObjectConnection
 
   LambdaInvokerProc = proc(arguments: seq[QVariant]) {.closure.}
@@ -137,3 +153,53 @@ type
 
 const
   UserRole* = 0x100
+
+proc `=destroy`(self: var QObjectObj) =
+  if self.owner and not self.vptr.isNil:
+    dos_qobject_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QVariantObj) =
+  if not self.vptr.isNil:
+    dos_qvariant_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QGuiApplicationObj) =
+  if not self.deleted:
+    dos_qguiapplication_delete()
+    self.deleted = true
+
+proc `=destroy`(self: var QHashIntByteArrayObj) =
+  if not self.vptr.isNil:
+    dos_qhash_int_qbytearray_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QMetaObjectObj) =
+  if not self.vptr.isNil:
+    dos_qmetaobject_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QMetaObjectConnectionObj) =
+  if not self.vptr.isNil:
+    dos_qmetaobject_connection_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QModelIndexObj) =
+  if not self.vptr.isNil:
+    dos_qmodelindex_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QQmlApplicationEngineObj) =
+  if not self.vptr.isNil:
+    dos_qqmlapplicationengine_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QQuickViewObj) =
+  if not self.vptr.isNil:
+    dos_qquickview_delete(self.vptr)
+    self.vptr = nil
+
+proc `=destroy`(self: var QUrlObj) =
+  if not self.vptr.isNil:
+    dos_qurl_delete(self.vptr)
+    self.vptr = nil

--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -41,9 +41,8 @@ proc dataCallback(modelPtr: pointer, rawIndex: DosQModelIndex, role: cint, resul
   let model = cast[QAbstractItemModel](modelPtr)
   let index = newQModelIndex(rawIndex, Ownership.Clone)
   let variant = data(model, index, role.int)
-  if variant != nil:
+  if variant != nil.QVariant:
     dos_qvariant_assign(result, variant.vptr)
-    variant.delete
 
 method setData*(self: QAbstractItemModel, index: QModelIndex, value: QVariant, role: int): bool {.base.} =
   ## Sets the data at the given index and role. Return true on success, false otherwise
@@ -87,7 +86,6 @@ proc headerDataCallback(modelPtr: pointer, section: cint, orientation: cint, rol
   let variant = model.headerData(section.int, orientation.QtOrientation, role.int)
   if variant != nil:
     dos_qvariant_assign(result, variant.vptr)
-    variant.delete
 
 proc createIndex*(self: QAbstractItemModel, row: int, column: int, data: pointer): QModelIndex =
   ## Create a new QModelIndex
@@ -155,13 +153,9 @@ proc setup*(self: QAbstractItemModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
+  let c = qobjectCallback
   self.vptr = dos_qabstractitemmodel_create(addr(self[]), self.metaObject.vptr,
-                                            qobjectCallback, qaimCallbacks).DosQObject
-
-proc delete*(self: QAbstractItemModel) =
-  ## Delete the given QAbstractItemModel
-  debugMsg("QAbstractItemModel", "delete")
-  self.QObject.delete()
+                                            c, qaimCallbacks).DosQObject
 
 proc hasIndex*(self: QAbstractItemModel, row: int, column: int, parent: QModelIndex): bool =
   debugMsg("QAbstractItemModel", "hasIndex")

--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -153,9 +153,8 @@ proc setup*(self: QAbstractItemModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
-  let c = qobjectCallback
   self.vptr = dos_qabstractitemmodel_create(addr(self[]), self.metaObject.vptr,
-                                            c, qaimCallbacks).DosQObject
+                                            qobjectCallback, qaimCallbacks).DosQObject
 
 proc hasIndex*(self: QAbstractItemModel, row: int, column: int, parent: QModelIndex): bool =
   debugMsg("QAbstractItemModel", "hasIndex")

--- a/src/nimqml/private/qabstractlistmodel.nim
+++ b/src/nimqml/private/qabstractlistmodel.nim
@@ -29,9 +29,8 @@ proc setup*(self: QAbstractListModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
-  let c = qobjectCallback
   self.vptr = dos_qabstractlistmodel_create(addr(self[]), self.metaObject.vptr,
-                                            c, qaimCallbacks).DosQObject
+                                            qobjectCallback, qaimCallbacks).DosQObject
 
 method columnCount(self: QAbstractListModel, index: QModelIndex): int =
   return dos_qabstractlistmodel_columnCount(self.vptr.DosQAbstractListModel, index.vptr)

--- a/src/nimqml/private/qabstractlistmodel.nim
+++ b/src/nimqml/private/qabstractlistmodel.nim
@@ -29,13 +29,9 @@ proc setup*(self: QAbstractListModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
+  let c = qobjectCallback
   self.vptr = dos_qabstractlistmodel_create(addr(self[]), self.metaObject.vptr,
-                                            qobjectCallback, qaimCallbacks).DosQObject
-
-proc delete*(self: QAbstractListModel) =
-  ## Delete the given QAbstractItemModel
-  debugMsg("QAbstractItemModel", "delete")
-  self.QObject.delete()
+                                            c, qaimCallbacks).DosQObject
 
 method columnCount(self: QAbstractListModel, index: QModelIndex): int =
   return dos_qabstractlistmodel_columnCount(self.vptr.DosQAbstractListModel, index.vptr)

--- a/src/nimqml/private/qabstracttablemodel.nim
+++ b/src/nimqml/private/qabstracttablemodel.nim
@@ -29,9 +29,8 @@ proc setup*(self: QAbstractTableModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
-  let c = qobjectCallback
   self.vptr = dos_qabstracttablemodel_create(addr(self[]), self.metaObject.vptr,
-                                            c, qaimCallbacks).DosQObject
+                                            qobjectCallback, qaimCallbacks).DosQObject
 
 method parent(self: QAbstractTableModel, child: QModelIndex): QModelIndex =
   let indexPtr = dos_qabstracttablemodel_parent(self.vptr.DosQAbstractTableModel, child.vptr)

--- a/src/nimqml/private/qabstracttablemodel.nim
+++ b/src/nimqml/private/qabstracttablemodel.nim
@@ -29,13 +29,9 @@ proc setup*(self: QAbstractTableModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
+  let c = qobjectCallback
   self.vptr = dos_qabstracttablemodel_create(addr(self[]), self.metaObject.vptr,
-                                            qobjectCallback, qaimCallbacks).DosQObject
-
-proc delete*(self: QAbstractTableModel) =
-  ## Delete the given QAbstractItemModel
-  debugMsg("QAbstractItemModel", "delete")
-  self.QObject.delete()
+                                            c, qaimCallbacks).DosQObject
 
 method parent(self: QAbstractTableModel, child: QModelIndex): QModelIndex =
   let indexPtr = dos_qabstracttablemodel_parent(self.vptr.DosQAbstractTableModel, child.vptr)

--- a/src/nimqml/private/qapplication.nim
+++ b/src/nimqml/private/qapplication.nim
@@ -21,5 +21,5 @@ proc delete*(application: QApplication) =
 
 proc newQApplication*(): QApplication =
   ## Return a new QApplication
-  new(result, delete)
+  new(result)
   result.setup()

--- a/src/nimqml/private/qguiapplication.nim
+++ b/src/nimqml/private/qguiapplication.nim
@@ -3,14 +3,6 @@ proc setup*(self: QGuiApplication) =
   dos_qguiapplication_create()
   self.deleted = false
 
-proc delete*(self: QGuiApplication) =
-  ## Delete the given QApplication
-  if self.deleted:
-    return
-  debugMsg("QApplication", "delete")
-  dos_qguiapplication_delete()
-  self.deleted = true
-
 proc exec*(self: QGuiApplication) =
   ## Start the Qt event loop
   dos_qguiapplication_exec()

--- a/src/nimqml/private/qhashintbytearray.nim
+++ b/src/nimqml/private/qhashintbytearray.nim
@@ -2,14 +2,6 @@ proc setup*(self: QHashIntByteArray) =
   ## Setup the QHash
   self.vptr = dos_qhash_int_qbytearray_create()
 
-proc delete*(self: QHashIntByteArray) =
-  ## Delete the QHash
-  if self.vptr.isNil:
-    return
-  debugMsg("QHashIntByteArray", "delete")
-  dos_qhash_int_qbytearray_delete(self.vptr)
-  self.vptr.resetToNil
-
 proc insert*(self: QHashIntByteArray, key: int, value: cstring) =
   ## Insert the value at the given key
   dos_qhash_int_qbytearray_insert(self.vptr, key, value)

--- a/src/nimqml/private/qmetaobject.nim
+++ b/src/nimqml/private/qmetaobject.nim
@@ -1,10 +1,3 @@
-proc delete*(metaObject: QMetaObject) =
-  ## Delete a QMetaObject
-  debugMsg("QMetaObject", "delete")
-  if metaObject.vptr.isNil:
-    return
-  dos_qmetaobject_delete(metaObject.vptr)
-  metaObject.vptr.resetToNil
 
 proc setup(superClass: QMetaObject,
            className: string,

--- a/src/nimqml/private/qmetaobjectconnection.nim
+++ b/src/nimqml/private/qmetaobjectconnection.nim
@@ -1,5 +1,0 @@
-proc delete*(self: QMetaObjectConnection) =
-  debugMsg("QMetaObjectConnection", "delete")
-  if self.vptr.isNil:
-    dos_qmetaobject_connection_delete(self.vptr)
-    self.vptr.resetToNil

--- a/src/nimqml/private/qmodelindex.nim
+++ b/src/nimqml/private/qmodelindex.nim
@@ -6,14 +6,6 @@ proc setup(self: QModelIndex, other: DosQModelIndex, takeOwnership: Ownership) =
   ## Setup a new QModelIndex
   self.vptr = if takeOwnership == Ownership.Take: other else: dos_qmodelindex_create_qmodelindex(other)
 
-proc delete*(self: QModelIndex) =
-  ## Delete the given QModelIndex
-  if not self.vptr.isNil:
-    return
-  debugMsg("QModelIndex", "delete")
-  dos_qmodelindex_delete(self.vptr)
-  self.vptr.resetToNil
-
 proc row*(self: QModelIndex): int =
   ## Return the index row
   dos_qmodelindex_row(self.vptr).int

--- a/src/nimqml/private/qobject.nim
+++ b/src/nimqml/private/qobject.nim
@@ -134,8 +134,7 @@ proc qobjectCallback(qobjectPtr: pointer, slotNamePtr: DosQVariant, dosArguments
 proc setup*(self: QObject) =
   ## Initialize a new QObject
   self.owner = true
-  let c = qobjectCallback
-  self.vptr = dos_qobject_create(addr(self[]), self.metaObject.vptr, c)
+  self.vptr = dos_qobject_create(addr(self[]), self.metaObject.vptr, qobjectCallback)
 
 proc deleteLater*(self: QObject) =
   debugMsg("QObject", "deleteLater")

--- a/src/nimqml/private/qqmlapplicationengine.nim
+++ b/src/nimqml/private/qqmlapplicationengine.nim
@@ -22,11 +22,3 @@ proc setRootContextProperty*(self: QQmlApplicationEngine, name: string, value: Q
   ## Set a root context property
   let context = dos_qqmlapplicationengine_context(self.vptr)
   dos_qqmlcontext_setcontextproperty(context, name.cstring, value.vptr)
-
-proc delete*(self: QQmlApplicationEngine) =
-  ## Delete the given QQmlApplicationEngine
-  debugMsg("QQmlApplicationEngine", "delete")
-  if self.vptr.isNil:
-    return
-  dos_qqmlapplicationengine_delete(self.vptr)
-  self.vptr.resetToNil

--- a/src/nimqml/private/qquickview.nim
+++ b/src/nimqml/private/qquickview.nim
@@ -2,14 +2,6 @@ proc setup*(self: QQuickView) =
   ## Setup a new QQuickView
   self.vptr = dos_qquickview_create()
 
-proc delete*(self: QQuickView) =
-  ## Delete the given QQuickView
-  if self.vptr.isNil:
-    return
-  debugMsg("QQuickView", "delete")
-  dos_qquickview_delete(self.vptr)
-  self.vptr.resetToNil
-
 proc source*(self: QQuickView): string =
   ## Return the source Qml file loaded by the view
   let str = dos_qquickview_source(self.vptr)

--- a/src/nimqml/private/qurl.nim
+++ b/src/nimqml/private/qurl.nim
@@ -2,14 +2,6 @@ proc setup*(self: QUrl, url: string, mode: QUrlParsingMode) =
   ## Setup a new QUrl
   self.vptr = dos_qurl_create(url.cstring, mode.cint)
 
-proc delete*(self: QUrl) =
-  ## Delete a QUrl
-  if self.vptr.isNil:
-    return
-  debugMsg("QUrl", "delete")
-  dos_qurl_delete(self.vptr)
-  self.vptr.resetToNil
-
 proc toString*(self: QUrl): string =
   ## Return the url string
   let str: cstring = dos_qurl_to_string(self.vptr)

--- a/src/nimqml/private/qvariant.nim
+++ b/src/nimqml/private/qvariant.nim
@@ -36,14 +36,6 @@ proc setup*(variant: QVariant, value: QVariant) =
   ## The inner value of the QVariant is copied
   setup(variant, value.vptr, Ownership.Clone)
 
-proc delete*(variant: QVariant) =
-  ## Delete a QVariant
-  if variant.vptr.isNil:
-    return
-  debugMsg("QVariant", "delete")
-  dos_qvariant_delete(variant.vptr)
-  variant.vptr.resetToNil
-
 proc isNull*(variant: QVariant): bool =
   ## Return true if the QVariant value is null, false otherwise
   dos_qvariant_isnull(variant.vptr)
@@ -104,11 +96,6 @@ proc toQVariantSequence(a: ptr DosQVariantArray, length: cint, takeOwnership: Ow
   result = @[]
   for i in 0..<length:
     result.add(newQVariant(a[i], takeOwnership))
-
-proc delete(a: openarray[QVariant]) =
-  ## Delete an array of QVariants
-  for x in a:
-    x.delete
 
 proc value*(self: QVariant, T: type string): string= self.stringVal
 proc value*(self: QVariant, T: type int): int = self.intVal


### PR DESCRIPTION
All legacy uses of `new(var, destructor)` and their explicit `delete()` procs have been removed.